### PR TITLE
docs(samples): update write samples & tests to support non-US regions

### DIFF
--- a/samples/append_rows_pending.js
+++ b/samples/append_rows_pending.js
@@ -74,8 +74,17 @@ function main(
 
       writeStream = response.name;
 
+      // This header is required so that the BigQuery Storage API
+      // knows which region to route the request to.
+      const options = {};
+      options.otherArgs = {};
+      options.otherArgs.headers = {};
+      options.otherArgs.headers[
+        'x-goog-request-params'
+      ] = `writeStream=${writeStream}`;
+
       // Append data to the given stream.
-      const stream = await writeClient.appendRows();
+      const stream = await writeClient.appendRows(options);
 
       const responses = [];
 

--- a/samples/append_rows_proto2.js
+++ b/samples/append_rows_proto2.js
@@ -137,8 +137,17 @@ function main(
 
       writeStream = response.name;
 
+      // This header is required so that the BigQuery Storage API
+      // knows which region to route the request to.
+      const options = {};
+      options.otherArgs = {};
+      options.otherArgs.headers = {};
+      options.otherArgs.headers[
+        'x-goog-request-params'
+      ] = `writeStream=${writeStream}`;
+
       // Append data to the given stream.
-      const stream = await writeClient.appendRows();
+      const stream = await writeClient.appendRows(options);
 
       const responses = [];
 


### PR DESCRIPTION
Updates write client samples to demonstrate setting `x-goog-request-params` header so requests are routed correctly.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #227  🦕
