### PR TITLE
fix: re-introduce routing headers for Write API

### DIFF
--- a/samples/append_rows_pending.js
+++ b/samples/append_rows_pending.js
@@ -73,8 +73,17 @@ function main(
 
       writeStream = response.name;
 
+      // This header is required so that the BigQuery Storage API
+      // knows which region to route the request to.
+      const options = {};
+      options.otherArgs = {};
+      options.otherArgs.headers = {};
+      options.otherArgs.headers[
+        'x-goog-request-params'
+      ] = `write_stream=${writeStream}`;
+
       // Append data to the given stream.
-      const stream = await writeClient.appendRows();
+      const stream = await writeClient.appendRows(options);
 
       const responses = [];
 

--- a/samples/append_rows_proto2.js
+++ b/samples/append_rows_proto2.js
@@ -72,8 +72,17 @@ function main(
 
       writeStream = response.name;
 
+      // This header is required so that the BigQuery Storage API
+      // knows which region to route the request to.
+      const options = {};
+      options.otherArgs = {};
+      options.otherArgs.headers = {};
+      options.otherArgs.headers[
+        'x-goog-request-params'
+      ] = `write_stream=${writeStream}`;
+
       // Append data to the given stream.
-      const stream = await writeClient.appendRows();
+      const stream = await writeClient.appendRows(options);
 
       const responses = [];
 

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -75,8 +75,17 @@ function main(
 
       writeStream = response.name;
 
+      // This header is required so that the BigQuery Storage API
+      // knows which region to route the request to.
+      const options = {};
+      options.otherArgs = {};
+      options.otherArgs.headers = {};
+      options.otherArgs.headers[
+        'x-goog-request-params'
+      ] = `write_stream=${writeStream}`;
+
       // Append data to the given stream.
-      const stream = await writeClient.appendRows();
+      const stream = await writeClient.appendRows(options);
 
       const responses = [];
 


### PR DESCRIPTION
Routing headers are still needed.

Fixes internal b/275088570 and revert #322 
