### PR TITLE
test: fix typescript version in pack-n-play system test

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jsdoc": "^4.0.0",
     "jsdoc-fresh": "^2.0.0",
     "jsdoc-region-tag": "^2.0.0",
-    "linkinator": "4.1.2",
+    "linkinator": "^4.0.0",
     "mocha": "^9.2.2",
     "null-loader": "^4.0.0",
     "pack-n-play": "^1.0.0-2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jsdoc": "^4.0.0",
     "jsdoc-fresh": "^2.0.0",
     "jsdoc-region-tag": "^2.0.0",
-    "linkinator": "^4.0.0",
+    "linkinator": "4.1.2",
     "mocha": "^9.2.2",
     "null-loader": "^4.0.0",
     "pack-n-play": "^1.0.0-2",

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -30,12 +30,14 @@ describe('📦 pack-n-play test', () => {
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.ts'
         ).toString(),
+        dependencies: ['typescript@4.8.3'],
       },
     };
     try {
       await packNTest(options);
     } catch (err) {
       console.error('TS install failed:', err);
+      throw err;
     }
   });
 
@@ -48,12 +50,14 @@ describe('📦 pack-n-play test', () => {
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.js'
         ).toString(),
+        dependencies: ['typescript@4.8.3'],
       },
     };
     try {
       await packNTest(options);
     } catch (err) {
       console.error('JS install failed:', err);
+      throw err;
     }
   });
 });

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -36,7 +36,7 @@ describe('📦 pack-n-play test', () => {
     try {
       await packNTest(options);
     } catch (err) {
-      console.error('TS install failed:', err);
+      console.error('TS install failed:\n', err);
       throw err;
     }
   });
@@ -56,7 +56,7 @@ describe('📦 pack-n-play test', () => {
     try {
       await packNTest(options);
     } catch (err) {
-      console.error('JS install failed:', err);
+      console.error('JS install failed:\n', err);
       throw err;
     }
   });

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -32,7 +32,11 @@ describe('📦 pack-n-play test', () => {
         ).toString(),
       },
     };
-    await packNTest(options);
+    try {
+      await packNTest(options);
+    } catch (err) {
+      console.error('TS install failed:', err);
+    }
   });
 
   it('JavaScript code', async function () {
@@ -46,6 +50,10 @@ describe('📦 pack-n-play test', () => {
         ).toString(),
       },
     };
-    await packNTest(options);
+    try {
+      await packNTest(options);
+    } catch (err) {
+      console.error('JS install failed:', err);
+    }
   });
 });


### PR DESCRIPTION
~Pin linkinator to v4.1.2 to avoid Node 16+ req~ linkinator was not the issue, was actually caused by latest release of Typescript not being compatible with Node 12 ( min requirement 14+ ).
