### PR TITLE
docs: improve samples for sending DATE, DATETIME and TIMESTAMP with Write API

### DIFF
--- a/samples/append_rows_proto2.js
+++ b/samples/append_rows_proto2.js
@@ -136,9 +136,10 @@ function main(
       serializedRows = [];
 
       // Row 7
+      const days = new Date('2019-02-07').getTime() / (1000 * 60 * 60 * 24);
       row = {
         rowNum: 7,
-        dateCol: 1132896,
+        dateCol: days, // The value is the number of days since the Unix epoch (1970-01-01)
       };
       serializedRows.push(SampleData.encode(row).finish());
 
@@ -172,10 +173,10 @@ function main(
       serializedRows.push(SampleData.encode(row).finish());
 
       // Row 12
-      const timestamp = 1641700186564;
+      const timestamp = new Date('2022-01-09T03:49:46.564Z').getTime();
       row = {
         rowNum: 12,
-        timestampCol: timestamp,
+        timestampCol: timestamp * 1000, // The value is given in microseconds since the Unix epoch (1970-01-01)
       };
       serializedRows.push(SampleData.encode(row).finish());
 

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -129,9 +129,10 @@ function main(
       rows = [];
 
       // Row 7
+      const days = new Date('2019-02-07').getTime() / (1000 * 60 * 60 * 24);
       row = {
         row_num: 7,
-        date_col: 1132896,
+        date_col: days, // The value is the number of days since the Unix epoch (1970-01-01)
       };
       rows.push(row);
 
@@ -165,9 +166,10 @@ function main(
       rows.push(row);
 
       // Row 12
+      const timestamp = new Date('2022-01-09T03:49:46.564Z').getTime();
       row = {
         row_num: 12,
-        timestamp_col: 1641700186564,
+        timestamp_col: timestamp * 1000, // The value is given in microseconds since the Unix epoch (1970-01-01)
       };
       rows.push(row);
 

--- a/samples/test/writeClient.js
+++ b/samples/test/writeClient.js
@@ -327,7 +327,7 @@ describe('writeClient', () => {
     assert.deepInclude(rows, [{float64_col: 987.6539916992188}, {row_num: 4}]);
     assert.deepInclude(rows, [{int64_col: 321}, {row_num: 5}]);
     assert.deepInclude(rows, [{string_col: 'octavia'}, {row_num: 6}]);
-    assert.deepInclude(rows, [{date_col: '5071-10-07'}, {row_num: 7}]);
+    assert.deepInclude(rows, [{date_col: '2019-02-07'}, {row_num: 7}]);
     assert.deepInclude(rows, [
       {datetime_col: '2019-02-17T11:24:00'},
       {row_num: 8},
@@ -340,7 +340,7 @@ describe('writeClient', () => {
     ]);
     assert.deepInclude(rows, [{time_col: '18:00:00'}, {row_num: 11}]);
     assert.deepInclude(rows, [
-      {timestamp_col: '1970-01-20T00:01:40.186564000Z'},
+      {timestamp_col: '2022-01-09T03:49:46.564Z'},
       {row_num: 12},
     ]);
     assert.deepInclude(rows, [{int64_list: [1999, 2001]}, {row_num: 13}]);


### PR DESCRIPTION
Improves sample to help with issues related to those datatypes, as reported by #419 and #344. This PR doesn't close those issues as we still can pursue a way to do this conversion automatically, but the encoding is handled by `protobufjs`, so this still needs more exploration.
