### PR TITLE
feat: automatically convert date/datetime/timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "extend": "^3.0.2",
-    "google-gax": "^4.0.3"
+    "google-gax": "^4.3.1",
+    "google-auth-library": "^9.6.3"
   },
   "peerDependencies": {
     "protobufjs": "^7.2.4"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
+    "extend": "^3.0.2",
     "google-gax": "^4.0.3"
   },
   "peerDependencies": {
@@ -34,10 +35,11 @@
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^7.0.0",
-    "@types/uuid": "^9.0.1",
+    "@types/extend": "^3.0.4",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.0.0",
     "@types/sinon": "^17.0.0",
+    "@types/uuid": "^9.0.1",
     "c8": "^9.0.0",
     "gapic-tools": "^0.3.0",
     "gts": "^5.0.0",
@@ -50,8 +52,8 @@
     "pack-n-play": "^2.0.0",
     "sinon": "^17.0.0",
     "ts-loader": "^9.0.0",
-    "uuid": "^9.0.0",
     "typescript": "^5.1.6",
+    "uuid": "^9.0.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^5.0.0"
   },

--- a/samples/append_rows_proto2.js
+++ b/samples/append_rows_proto2.js
@@ -136,9 +136,10 @@ function main(
       serializedRows = [];
 
       // Row 7
+      const days = new Date('2019-02-07').getTime() / (1000 * 60 * 60 * 24);
       row = {
         rowNum: 7,
-        dateCol: 1132896,
+        dateCol: days, // The value is the number of days since the Unix epoch (1970-01-01)
       };
       serializedRows.push(SampleData.encode(row).finish());
 
@@ -172,10 +173,10 @@ function main(
       serializedRows.push(SampleData.encode(row).finish());
 
       // Row 12
-      const timestamp = 1641700186564;
+      const timestamp = new Date('2022-01-09T03:49:46.564Z').getTime();
       row = {
         rowNum: 12,
-        timestampCol: timestamp,
+        timestampCol: timestamp * 1000, // The value is given in microseconds since the Unix epoch (1970-01-01)
       };
       serializedRows.push(SampleData.encode(row).finish());
 

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -129,9 +129,10 @@ function main(
       rows = [];
 
       // Row 7
+      const days = new Date('2019-02-07').getTime() / (1000 * 60 * 60 * 24);
       row = {
         row_num: 7,
-        date_col: 1132896,
+        date_col: days, // The value is the number of days since the Unix epoch (1970-01-01)
       };
       rows.push(row);
 
@@ -165,9 +166,10 @@ function main(
       rows.push(row);
 
       // Row 12
+      const timestamp = new Date('2022-01-09T03:49:46.564Z').getTime();
       row = {
         row_num: 12,
-        timestamp_col: 1641700186564,
+        timestamp_col: timestamp * 1000, // The value is given in microseconds since the Unix epoch (1970-01-01)
       };
       rows.push(row);
 

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -60,7 +60,6 @@ function main(
       const writer = new JSONWriter({
         connection,
         protoDescriptor,
-        convertDates: true,
       });
 
       let rows = [];

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -58,9 +58,9 @@ function main(
       console.log(`Stream created: ${streamId}`);
 
       const writer = new JSONWriter({
-        streamId,
         connection,
         protoDescriptor,
+        convertDates: true,
       });
 
       let rows = [];
@@ -129,17 +129,16 @@ function main(
       rows = [];
 
       // Row 7
-      const days = new Date('2019-02-07').getTime() / (1000 * 60 * 60 * 24);
       row = {
         row_num: 7,
-        date_col: days, // The value is the number of days since the Unix epoch (1970-01-01)
+        date_col: new Date('2019-02-07'),
       };
       rows.push(row);
 
       // Row 8
       row = {
         row_num: 8,
-        datetime_col: bigquery.datetime('2019-02-17 11:24:00.000').value, // BigQuery civil time
+        datetime_col: new Date('2019-02-17T11:24:00.000Z'),
       };
       rows.push(row);
 
@@ -166,10 +165,9 @@ function main(
       rows.push(row);
 
       // Row 12
-      const timestamp = new Date('2022-01-09T03:49:46.564Z').getTime();
       row = {
         row_num: 12,
-        timestamp_col: timestamp * 1000, // The value is given in microseconds since the Unix epoch (1970-01-01)
+        timestamp_col: new Date('2022-01-09T03:49:46.564Z'),
       };
       rows.push(row);
 

--- a/samples/test/writeClient.js
+++ b/samples/test/writeClient.js
@@ -327,7 +327,7 @@ describe('writeClient', () => {
     assert.deepInclude(rows, [{float64_col: 987.6539916992188}, {row_num: 4}]);
     assert.deepInclude(rows, [{int64_col: 321}, {row_num: 5}]);
     assert.deepInclude(rows, [{string_col: 'octavia'}, {row_num: 6}]);
-    assert.deepInclude(rows, [{date_col: '5071-10-07'}, {row_num: 7}]);
+    assert.deepInclude(rows, [{date_col: '2019-02-07'}, {row_num: 7}]);
     assert.deepInclude(rows, [
       {datetime_col: '2019-02-17T11:24:00'},
       {row_num: 8},
@@ -340,7 +340,7 @@ describe('writeClient', () => {
     ]);
     assert.deepInclude(rows, [{time_col: '18:00:00'}, {row_num: 11}]);
     assert.deepInclude(rows, [
-      {timestamp_col: '1970-01-20T00:01:40.186564000Z'},
+      {timestamp_col: '2022-01-09T03:49:46.564Z'},
       {row_num: 12},
     ]);
     assert.deepInclude(rows, [{int64_list: [1999, 2001]}, {row_num: 13}]);

--- a/src/managedwriter/encoder.ts
+++ b/src/managedwriter/encoder.ts
@@ -34,7 +34,6 @@ export class JSONEncoder {
   private _type: protobuf.Type = Type.fromJSON('root', {
     fields: {},
   });
-  private _convertDates: boolean;
 
   /**
    * Creates a new JSONEncoder instance.
@@ -42,17 +41,9 @@ export class JSONEncoder {
    * @param {Object} params - The parameters for the JSONEncoder.
    * @param {IDescriptorProto} params.protoDescriptor - The proto descriptor
    *   for the JSON rows.
-   * @param {boolean} params.convertDates - Deep inspect each appended row object
-   *   and convert Javascript Date to the proper BigQuery Protobuf representation
-   *   per https://cloud.google.com/bigquery/docs/write-api#data_type_conversions.
-   *   This is an EXPERIMENTAL parameter and subject to change or removal without notice.
    */
-  constructor(params: {
-    protoDescriptor: IDescriptorProto;
-    convertDates?: boolean;
-  }) {
-    const {convertDates, protoDescriptor} = params;
-    this._convertDates = convertDates || false;
+  constructor(params: {protoDescriptor: IDescriptorProto}) {
+    const {protoDescriptor} = params;
     this.setProtoDescriptor(protoDescriptor);
   }
 
@@ -97,9 +88,6 @@ export class JSONEncoder {
   }
 
   private convertRow(source: any): Object {
-    if (!this._convertDates) {
-      return source;
-    }
     const row = extend(true, {}, source);
     for (const key in row) {
       const value = row[key];

--- a/src/managedwriter/encoder.ts
+++ b/src/managedwriter/encoder.ts
@@ -79,10 +79,7 @@ export class JSONEncoder {
   encodeRows(rows: any[]): Uint8Array[] {
     const serializedRows = rows
       .map(r => {
-        const converted = this.convertRow(r);
-        console.log('Original', r);
-        console.log('Converted', converted);
-        return converted;
+        return this.convertRow(r);
       })
       .map(r => {
         return this.encodeRow(r);

--- a/src/managedwriter/encoder.ts
+++ b/src/managedwriter/encoder.ts
@@ -92,7 +92,7 @@ export class JSONEncoder {
 
   private isPlainObject(value: any): boolean {
     return value && [undefined, Object].includes(value.constructor);
-  } 
+  }
 
   private encodeRow(row: any): Uint8Array {
     const msg = this._type.create(row);
@@ -102,9 +102,9 @@ export class JSONEncoder {
   private convertRow(source: any): Object {
     if (!this._convertDates) {
       return source;
-    }        
-    const row = extend(true, {} , source);
-    for (let key in row) {
+    }
+    const row = extend(true, {}, source);
+    for (const key in row) {
       const value = row[key];
       if (value === null) {
         continue;
@@ -134,7 +134,7 @@ export class JSONEncoder {
           if (!this.isPlainObject(v)) {
             return v;
           }
-          return this.convertRow(v)
+          return this.convertRow(v);
         });
         continue;
       }

--- a/src/managedwriter/encoder.ts
+++ b/src/managedwriter/encoder.ts
@@ -1,0 +1,148 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as protobuf from 'protobufjs';
+import * as protos from '../../protos/protos';
+import {normalizeDescriptor} from '../adapt/proto';
+import * as extend from 'extend';
+
+type IDescriptorProto = protos.google.protobuf.IDescriptorProto;
+type DescriptorProto = protos.google.protobuf.DescriptorProto;
+
+const DescriptorProto = protos.google.protobuf.DescriptorProto;
+const {Type} = protobuf;
+
+/**
+ * Internal class used by the JSONWriter to convert JSON data to protobuf messages.
+ * It can be configure to do some data conversion to match what BigQuery expects.
+ *
+ * @class
+ * @memberof managedwriter
+ */
+export class JSONEncoder {
+  private _type: protobuf.Type = Type.fromJSON('root', {
+    fields: {},
+  });
+  private _convertDates: boolean;
+
+  /**
+   * Creates a new JSONEncoder instance.
+   *
+   * @param {Object} params - The parameters for the JSONEncoder.
+   * @param {IDescriptorProto} params.protoDescriptor - The proto descriptor
+   *   for the JSON rows.
+   * @param {boolean} params.convertDates - Deep inspect each appended row object
+   *   and convert Javascript Date to the proper BigQuery Protobuf representation
+   *   per https://cloud.google.com/bigquery/docs/write-api#data_type_conversions.
+   *   This is an EXPERIMENTAL parameter and subject to change or removal without notice.
+   */
+  constructor(params: {
+    protoDescriptor: IDescriptorProto;
+    convertDates?: boolean;
+  }) {
+    const {convertDates, protoDescriptor} = params;
+    this._convertDates = convertDates || false;
+    this.setProtoDescriptor(protoDescriptor);
+  }
+
+  /**
+   * Update the proto descriptor for the Encoder.
+   *
+   * @param {IDescriptorProto} protoDescriptor - The proto descriptor.
+   */
+  setProtoDescriptor(protoDescriptor: IDescriptorProto): void {
+    const normalized = normalizeDescriptor(
+      new DescriptorProto(protoDescriptor)
+    );
+    this._type = Type.fromDescriptor(normalized);
+  }
+
+  /**
+   * Writes a JSONList that contains objects to be written to the BigQuery table by first converting
+   * the JSON data to protobuf messages, then using Writer's appendRows() to write the data at current end
+   * of stream. If there is a schema update, the current Writer is closed and reopened with the updated schema.
+   *
+   * @param {JSONList} rows - The list of JSON rows.
+   * @returns {Uint8Array[]} The encoded rows.
+   */
+  encodeRows(rows: any[]): Uint8Array[] {
+    const serializedRows = rows
+      .map(r => {
+        const converted = this.convertRow(r);
+        console.log('Original', r);
+        console.log('Converted', converted);
+        return converted;
+      })
+      .map(r => {
+        return this.encodeRow(r);
+      });
+    return serializedRows;
+  }
+
+  private isPlainObject(value: any): boolean {
+    return value && [undefined, Object].includes(value.constructor);
+  } 
+
+  private encodeRow(row: any): Uint8Array {
+    const msg = this._type.create(row);
+    return this._type.encode(msg).finish();
+  }
+
+  private convertRow(source: any): Object {
+    if (!this._convertDates) {
+      return source;
+    }        
+    const row = extend(true, {} , source);
+    for (let key in row) {
+      const value = row[key];
+      if (value === null) {
+        continue;
+      }
+      if (value instanceof Date) {
+        const pfield = this._type.fields[key];
+        if (!pfield) {
+          continue;
+        }
+        switch (pfield.type) {
+          case 'int32': // DATE
+            // The value is the number of days since the Unix epoch (1970-01-01)
+            row[key] = value.getTime() / (1000 * 60 * 60 * 24);
+            break;
+          case 'int64': // TIMESTAMP
+            // The value is given in microseconds since the Unix epoch (1970-01-01)
+            row[key] = value.getTime() * 1000;
+            break;
+          case 'string': // DATETIME
+            row[key] = value.toJSON().replace(/^(.*)T(.*)Z$/, '$1 $2');
+            break;
+        }
+        continue;
+      }
+      if (Array.isArray(value)) {
+        row[key] = value.map(v => {
+          if (!this.isPlainObject(v)) {
+            return v;
+          }
+          return this.convertRow(v)
+        });
+        continue;
+      }
+      if (this.isPlainObject(value)) {
+        row[key] = this.convertRow(value);
+        continue;
+      }
+    }
+    return row;
+  }
+}

--- a/src/managedwriter/index.ts
+++ b/src/managedwriter/index.ts
@@ -18,7 +18,7 @@
  * More information about this new write client may also be found in
  * the public documentation: https://cloud.google.com/bigquery/docs/write-api
  *
- * It is EXPERIMENTAL and subject to change or removal without notice.  This is primarily to signal that this
+ * It is EXPERIMENTAL and subject to change or removal without notice. This is primarily to signal that this
  * package may still make breaking changes to existing methods and functionality.
  *
  * @namespace managedwriter

--- a/src/managedwriter/json_writer.ts
+++ b/src/managedwriter/json_writer.ts
@@ -54,21 +54,15 @@ export class JSONWriter {
    *   to the BigQuery streaming insert operation.
    * @param {IDescriptorProto} params.protoDescriptor - The proto descriptor
    *   for the JSON rows.
-   * @param {boolean} params.convertDates - Deep inspect each appended row object
-   *   and convert Javascript Date to the proper BigQuery Protobuf representation
-   *   per https://cloud.google.com/bigquery/docs/write-api#data_type_conversions.
-   *   This is an EXPERIMENTAL parameter and subject to change or removal without notice.
    */
   constructor(params: {
     connection: StreamConnection;
     protoDescriptor: IDescriptorProto;
-    convertDates?: boolean;
   }) {
-    const {connection, protoDescriptor, convertDates} = params;
+    const {connection, protoDescriptor} = params;
     this._writer = new Writer(params);
     this._encoder = new JSONEncoder({
       protoDescriptor: params.protoDescriptor,
-      convertDates: params.convertDates,
     });
     this._schemaListener = connection.onSchemaUpdated(this.onSchemaUpdated);
     this.setProtoDescriptor(protoDescriptor);

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -420,7 +420,7 @@ describe('managedwriter.WriterClient', () => {
         customer_name: 'Ada Lovelace',
         row_num: 1,
         customer_birthday: -56270,
-        customer_created_at: '2022-01-09T03:49:46.564Z',
+        customer_created_at: '2022-01-09 03:49:46.564',
         customer_updated_at: 1673236186564000,
       });
 
@@ -430,7 +430,7 @@ describe('managedwriter.WriterClient', () => {
         customer_name: 'Alan Turing',
         row_num: 2,
         customer_birthday: -20981,
-        customer_created_at: '2022-01-09T03:49:46.564Z',
+        customer_created_at: '2022-01-09 03:49:46.564',
         customer_updated_at: 1673236186564000,
       });
     });

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -22,6 +22,7 @@ import * as bigquerywriter from '../src';
 import * as protobuf from 'protobufjs';
 import {ClientOptions} from 'google-gax';
 import * as customerRecordProtoJson from '../samples/customer_record.json';
+import {JSONEncoder} from '../src/managedwriter/encoder';
 
 const {managedwriter, adapt} = bigquerywriter;
 const {WriterClient, Writer, JSONWriter, parseStorageErrors} = managedwriter;
@@ -361,6 +362,77 @@ describe('managedwriter.WriterClient', () => {
       } finally {
         client.close();
       }
+    });
+  });
+
+  describe('JSONEncoder', () => {
+    it('should automatically convert date/datetime/timestamps to expect BigQuery format', () => {
+      const updatedSchema = {
+        fields: [
+          ...(schema.fields || []),
+          {
+            name: 'customer_birthday',
+            type: 'DATE',
+          },
+          {
+            name: 'customer_created_at',
+            type: 'DATETIME',
+          },
+          {
+            name: 'customer_updated_at',
+            type: 'TIMESTAMP',
+          },
+        ],
+      };
+      const storageSchema =
+        adapt.convertBigQuerySchemaToStorageTableSchema(updatedSchema);
+      const protoDescriptor: DescriptorProto =
+        adapt.convertStorageSchemaToProto2Descriptor(storageSchema, 'root');
+      const encoder = new JSONEncoder({
+        protoDescriptor,
+        convertDates: true,
+      });
+
+      // Row 1
+      const row1 = {
+        customer_name: 'Ada Lovelace',
+        row_num: 1,
+        customer_birthday: new Date('1815-12-10'),
+        customer_created_at: new Date('2022-01-09T03:49:46.564Z'),
+        customer_updated_at: new Date('2023-01-09T03:49:46.564Z'),
+      };
+
+      // Row 2
+      const row2 = {
+        customer_name: 'Alan Turing',
+        row_num: 2,
+        customer_birthday: new Date('1912-07-23'),
+        customer_created_at: new Date('2022-01-09T03:49:46.564Z'),
+        customer_updated_at: new Date('2023-01-09T03:49:46.564Z'),
+      };
+
+      const Proto = Type.fromDescriptor(protoDescriptor);
+      const encoded = encoder.encodeRows([row1, row2]);
+
+      const encodedRow1 = encoded[0];
+      const decodedRow1 = Proto.decode(encodedRow1).toJSON();
+      assert.deepEqual(decodedRow1, {
+        customer_name: 'Ada Lovelace',
+        row_num: 1,
+        customer_birthday: -56270,
+        customer_created_at: '2022-01-09T03:49:46.564Z',
+        customer_updated_at: 1673236186564000,
+      });
+
+      const encodedRow2 = encoded[1];
+      const decodedRow2 = Proto.decode(encodedRow2).toJSON();
+      assert.deepEqual(decodedRow2, {
+        customer_name: 'Alan Turing',
+        row_num: 2,
+        customer_birthday: -20981,
+        customer_created_at: '2022-01-09T03:49:46.564Z',
+        customer_updated_at: 1673236186564000,
+      });
     });
   });
 

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -390,7 +390,6 @@ describe('managedwriter.WriterClient', () => {
         adapt.convertStorageSchemaToProto2Descriptor(storageSchema, 'root');
       const encoder = new JSONEncoder({
         protoDescriptor,
-        convertDates: true,
       });
 
       // Row 1


### PR DESCRIPTION
Automatically converts DATE/DATETIME/TIMESTAMP accordingly to BigQuery Write API Docs. For doing this, we clone deep objects passed by the user, inspect each attribute to see if a Javascript Date exists, then convert to the appropriate format expect by the service side.

Still TDB if this is going to be an opt-in feature or enabled by default.

Fixes #419 #344 🦕
