### PR TITLE
fix: destroy internal grpc conn when closed

### DIFF
--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -327,6 +327,7 @@ export class StreamConnection extends EventEmitter {
     }
     this._connection.end();
     this._connection.removeAllListeners();
+    this._connection.destroy();
     this._connection = null;
   }
 

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1269,6 +1269,7 @@ describe('managedwriter.WriterClient', () => {
           destinationTable: parent,
         });
         const connection = await client.createStreamConnection({streamId});
+        const internalConn = connection['_connection']!;
         const writer = new Writer({
           connection,
           protoDescriptor,
@@ -1284,6 +1285,7 @@ describe('managedwriter.WriterClient', () => {
         writer.close();
         client.close();
         assert.strictEqual(client.isOpen(), false);
+        assert.strictEqual(internalConn.destroyed, true);
       } finally {
         client.close();
       }


### PR DESCRIPTION
In cases where the connection was not used and ended, some errors can be raised and are not handled due to the internal event listeners being removed. This PR add code to destroy the internal grpc connection to ensure no errors are raised after it's closed.

Fixes #348  🦕
