### PR TITLE
feat: enable write retry and nack pending writes on reconnect

### DIFF
--- a/src/managedwriter/pending_write.ts
+++ b/src/managedwriter/pending_write.ts
@@ -28,22 +28,22 @@ type AppendRowRequest =
 export class PendingWrite {
   private request: AppendRowRequest;
   private response?: AppendRowsResponse;
-  private retryAttempts: number;
+  private attempts: number;
   private promise: Promise<AppendRowsResponse>;
   private resolveFunc?: (response: AppendRowsResponse) => void;
   private rejectFunc?: (reason?: protos.google.rpc.IStatus) => void;
 
   constructor(request: AppendRowRequest) {
     this.request = request;
-    this.retryAttempts = 0;
+    this.attempts = 0;
     this.promise = new Promise((resolve, reject) => {
       this.resolveFunc = resolve;
       this.rejectFunc = reject;
     });
   }
 
-  _increaseRetryAttempts(): number {
-    return this.retryAttempts++;
+  _increaseAttempts(): number {
+    return this.attempts++;
   }
 
   _markDone(err: Error | null, response?: AppendRowsResponse) {

--- a/src/managedwriter/pending_write.ts
+++ b/src/managedwriter/pending_write.ts
@@ -28,16 +28,22 @@ type AppendRowRequest =
 export class PendingWrite {
   private request: AppendRowRequest;
   private response?: AppendRowsResponse;
+  private retryAttempts: number;
   private promise: Promise<AppendRowsResponse>;
   private resolveFunc?: (response: AppendRowsResponse) => void;
   private rejectFunc?: (reason?: protos.google.rpc.IStatus) => void;
 
   constructor(request: AppendRowRequest) {
     this.request = request;
+    this.retryAttempts = 0;
     this.promise = new Promise((resolve, reject) => {
       this.resolveFunc = resolve;
       this.rejectFunc = reject;
     });
+  }
+
+  _increaseRetryAttempts(): number {
+    return this.retryAttempts++;
   }
 
   _markDone(err: Error | null, response?: AppendRowsResponse) {

--- a/src/managedwriter/pending_write.ts
+++ b/src/managedwriter/pending_write.ts
@@ -42,10 +42,27 @@ export class PendingWrite {
     });
   }
 
+  /**
+   * Increase number of attempts and return current value.
+   *
+   * @private
+   * @internal
+   * @returns {number} current number of attempts
+   */
   _increaseAttempts(): number {
     return this.attempts++;
   }
 
+  /**
+   * Resolve pending write with error or AppendRowResponse.
+   * This resolves the promise accessed via GetResult()
+   *
+   * @see GetResult
+   *
+   * @private
+   * @internal
+   * @returns {number} current number of attempts
+   */
   _markDone(err: Error | null, response?: AppendRowsResponse) {
     if (err) {
       this.rejectFunc && this.rejectFunc(err);

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -393,7 +393,6 @@ export class StreamConnection extends EventEmitter {
   async flushRows(request?: {
     offset?: IInt64Value['value'];
   }): Promise<FlushRowsResponse | null> {
-    this.close();
     if (this.isDefaultStream()) {
       return null;
     }

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -119,7 +119,7 @@ export class StreamConnection extends EventEmitter {
       this.emit('error', err);
       return;
     }
-    let nextPendingWrite = this.getNextPendingWrite();
+    const nextPendingWrite = this.getNextPendingWrite();
     if (nextPendingWrite) {
       this.trace(
         'found request error with pending write',
@@ -180,8 +180,9 @@ export class StreamConnection extends EventEmitter {
     }
     // This header is required so that the BigQuery Storage API
     // knows which region to route the request to.
-    callOptions.otherArgs.headers['x-goog-request-params'] =
-      `write_stream=${streamId}`;
+    callOptions.otherArgs.headers[
+      'x-goog-request-params'
+    ] = `write_stream=${streamId}`;
     return callOptions;
   }
 

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -185,9 +185,8 @@ export class StreamConnection extends EventEmitter {
     }
     // This header is required so that the BigQuery Storage API
     // knows which region to route the request to.
-    callOptions.otherArgs.headers[
-      'x-goog-request-params'
-    ] = `write_stream=${streamId}`;
+    callOptions.otherArgs.headers['x-goog-request-params'] =
+      `write_stream=${streamId}`;
     return callOptions;
   }
 

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -19,7 +19,6 @@ import * as protos from '../../protos/protos';
 import {WriterClient} from './writer_client';
 import {PendingWrite} from './pending_write';
 import {logger} from './logger';
-import {parseStorageErrors} from './error';
 
 type TableSchema = protos.google.cloud.bigquery.storage.v1.ITableSchema;
 type IInt64Value = protos.google.protobuf.IInt64Value;

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -265,12 +265,12 @@ export class StreamConnection extends EventEmitter {
   }
 
   private resendAllPendingWrites() {
-    const pendingWrites = [...this._pendingWrites]; // copy array;
-    let pw = pendingWrites.pop();
+    const pendingWritesToRetry = [...this._pendingWrites]; // copy array;
+    let pw = pendingWritesToRetry.pop();
     while (pw) {
       this._pendingWrites.pop(); // remove from real queue
       this.send(pw); // .send immediately adds to the queue
-      pw = pendingWrites.pop();
+      pw = pendingWritesToRetry.pop();
     }
   }
 
@@ -321,7 +321,7 @@ export class StreamConnection extends EventEmitter {
 
   private send(pw: PendingWrite) {
     const retrySettings = this._writeClient['_retrySettings'];
-    const tries = pw._increaseRetryAttempts();
+    const tries = pw._increaseAttempts();
     if (tries > retrySettings.maxRetryAttempts) {
       pw._markDone(
         new Error(`pending write max retries reached: ${tries} attempts`)

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -141,6 +141,9 @@ export class StreamConnection extends EventEmitter {
       }
       return;
     }
+    if (this.isRetryableError(err) && this.listenerCount('error') === 0) {
+      return;
+    }
     this.emit('error', err);
   };
 

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -358,9 +358,7 @@ export class StreamConnection extends EventEmitter {
    */
   reconnect() {
     this.trace(
-      'reconnect called with',
-      this._pendingWrites.length,
-      'pending writes'
+      `reconnect called with ${this._pendingWrites.length} pending writes`
     );
     this.close();
     this.open();

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -357,7 +357,11 @@ export class StreamConnection extends EventEmitter {
    * Re open appendRows BiDi gRPC connection.
    */
   reconnect() {
-    this.trace('reconnect called');
+    this.trace(
+      'reconnect called with',
+      this._pendingWrites.length,
+      'pending writes'
+    );
     this.close();
     this.open();
   }

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -151,7 +151,6 @@ export class StreamConnection extends EventEmitter {
       gax.Status.CANCELLED,
       gax.Status.INTERNAL,
       gax.Status.DEADLINE_EXCEEDED,
-      gax.Status.RESOURCE_EXHAUSTED,
     ];
     return !!err.code && errorCodes.includes(err.code);
   }
@@ -189,15 +188,6 @@ export class StreamConnection extends EventEmitter {
     }
     if (response.updatedSchema) {
       this.emit('schemaUpdated', response.updatedSchema);
-    }
-    const rerr = response.error;
-    if (rerr) {
-      const gerr = new gax.GoogleError(rerr.message!);
-      gerr.code = rerr.code!;
-      if (this.isRetryableError(gerr)) {
-        this.handleRetry(gerr);
-        return;
-      }
     }
     this.ackNextPendingWrite(null, response);
   };

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -98,9 +98,9 @@ export class StreamConnection extends EventEmitter {
           this.resendAllPendingWrites();
         } else {
           const err = new gax.GoogleError(
-            'aborted due to failed connection, please retry the request'
+            'Connection failure, please retry the request'
           );
-          err.code = gax.Status.ABORTED;
+          err.code = gax.Status.UNAVAILABLE;
           this.ackAllPendingWrites(err);
         }
       }

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -327,6 +327,7 @@ export class StreamConnection extends EventEmitter {
       pw._markDone(
         new Error(`pending write max retries reached: ${tries} attempts`)
       );
+      return;
     }
     if (this.isConnectionClosed()) {
       this.reconnect();

--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -180,9 +180,8 @@ export class StreamConnection extends EventEmitter {
     }
     // This header is required so that the BigQuery Storage API
     // knows which region to route the request to.
-    callOptions.otherArgs.headers[
-      'x-goog-request-params'
-    ] = `write_stream=${streamId}`;
+    callOptions.otherArgs.headers['x-goog-request-params'] =
+      `write_stream=${streamId}`;
     return callOptions;
   }
 

--- a/src/managedwriter/writer.ts
+++ b/src/managedwriter/writer.ts
@@ -160,7 +160,7 @@ export class Writer {
     offsetValue?: IInt64Value['value']
   ): PendingWrite {
     let offset: AppendRowRequest['offset'];
-    if (offsetValue) {
+    if (offsetValue || offsetValue === 0) {
       offset = {
         value: offsetValue,
       };

--- a/src/managedwriter/writer.ts
+++ b/src/managedwriter/writer.ts
@@ -160,7 +160,7 @@ export class Writer {
     offsetValue?: IInt64Value['value']
   ): PendingWrite {
     let offset: AppendRowRequest['offset'];
-    if (offsetValue || offsetValue === 0) {
+    if (offsetValue !== undefined && offsetValue !== null) {
       offset = {
         value: offsetValue,
       };

--- a/src/managedwriter/writer_client.ts
+++ b/src/managedwriter/writer_client.ts
@@ -59,7 +59,12 @@ export class WriterClient {
   private _client: BigQueryWriteClient;
   private _connections: StreamConnections;
   private _open: boolean;
-  private _retrySettings: RetrySettings;
+  /**
+   * Retry settings, only internal for now.
+   * @private
+   * @internal
+   */
+  _retrySettings: RetrySettings;
 
   constructor(opts?: ClientOptions) {
     const baseOptions = {

--- a/src/managedwriter/writer_client.ts
+++ b/src/managedwriter/writer_client.ts
@@ -111,13 +111,27 @@ export class WriterClient {
     return this._open;
   }
 
-  // Enables StreamConnections to automatically retry failed appends.
-  //
-  // Enabling retries is best suited for cases where users want to achieve at-least-once
-  // append semantics. Use of automatic retries may complicate patterns where the user
-  // is designing for exactly-once append semantics.
+  /**
+   * Enables StreamConnections to automatically retry failed appends.
+   *
+   * Enabling retries is best suited for cases where users want to achieve at-least-once
+   * append semantics. Use of automatic retries may complicate patterns where the user
+   * is designing for exactly-once append semantics.
+   */
   enableWriteRetries(enable: boolean) {
     this._retrySettings.enableWriteRetries = enable;
+  }
+
+  /**
+   * Change max retries attempts on child StreamConnections.
+   *
+   * The default valuen is to retry 4 times.
+   *
+   * Only valid right now when write retries are enabled.
+   * @see enableWriteRetries.
+   */
+  setMaxRetryAttempts(retryAttempts: number) {
+    this._retrySettings.maxRetryAttempts = retryAttempts;
   }
 
   /**

--- a/src/managedwriter/writer_client.ts
+++ b/src/managedwriter/writer_client.ts
@@ -23,6 +23,10 @@ import {StreamConnection} from './stream_connection';
 type StreamConnections = {
   connectionList: StreamConnection[];
 };
+type RetrySettings = {
+  enableWriteRetries: boolean;
+  maxRetryAttempts: number;
+};
 type CreateWriteStreamRequest =
   protos.google.cloud.bigquery.storage.v1.ICreateWriteStreamRequest;
 type BatchCommitWriteStreamsRequest =
@@ -55,6 +59,7 @@ export class WriterClient {
   private _client: BigQueryWriteClient;
   private _connections: StreamConnections;
   private _open: boolean;
+  private _retrySettings: RetrySettings;
 
   constructor(opts?: ClientOptions) {
     const baseOptions = {
@@ -69,6 +74,10 @@ export class WriterClient {
       connectionList: [],
     };
     this._open = false;
+    this._retrySettings = {
+      enableWriteRetries: false,
+      maxRetryAttempts: 4,
+    };
   }
 
   /**
@@ -100,6 +109,15 @@ export class WriterClient {
    */
   isOpen(): boolean {
     return this._open;
+  }
+
+  // Enables StreamConnections to automatically retry failed appends.
+  //
+  // Enabling retries is best suited for cases where users want to achieve at-least-once
+  // append semantics. Use of automatic retries may complicate patterns where the user
+  // is designing for exactly-once append semantics.
+  enableWriteRetries(enable: boolean) {
+    this._retrySettings.enableWriteRetries = enable;
   }
 
   /**

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1444,10 +1444,6 @@ describe('managedwriter.WriterClient', () => {
           destinationTable: parent,
         });
 
-        connection.onConnectionError(err => {
-          console.log('idle conn err', err);
-        });
-
         const writer = new JSONWriter({
           connection,
           protoDescriptor,

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1036,10 +1036,10 @@ describe('managedwriter.WriterClient', () => {
 
           const pendingWrites: PendingWrite[] = [];
           const iterations = new Array(50).fill(1);
-          let offset = 10;
+          let offset = 0;
           for (const _ of iterations) {
             const rows = generateRows(10);
-            const pw = writer.appendRows(rows);
+            const pw = writer.appendRows(rows, offset);
             pendingWrites.push(pw);
             offset += 10;
           }
@@ -1104,10 +1104,10 @@ describe('managedwriter.WriterClient', () => {
 
           const pendingWrites: PendingWrite[] = [];
           const iterations = new Array(50).fill(1);
-          let offset = 10;
+          let offset = 0;
           for (const _ of iterations) {
             const rows = generateRows(10);
-            const pw = writer.appendRows(rows);
+            const pw = writer.appendRows(rows, offset);
             pendingWrites.push(pw);
             offset += 10;
           }

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1081,7 +1081,7 @@ describe('managedwriter.WriterClient', () => {
                 const req = chunk as AppendRowRequest;
                 cb && cb(null);
                 numCalls++;
-                if (!req.writeStream){
+                if (!req.writeStream) {
                   return false;
                 }
                 if (numCalls % 10 === 0) {

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it} from 'mocha';
+import {describe, it, xit} from 'mocha';
 import * as uuid from 'uuid';
 import * as gax from 'google-gax';
 import * as sinon from 'sinon';
@@ -929,6 +929,7 @@ describe('managedwriter.WriterClient', () => {
 
           const iterations = new Array(50).fill(1);
           let offset = 0;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           for (const _ of iterations) {
             const rows = generateRows(10);
             const pw = writer.appendRows(rows, offset);
@@ -980,6 +981,7 @@ describe('managedwriter.WriterClient', () => {
 
           const iterations = new Array(50).fill(1);
           let offset = 0;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           for (const _ of iterations) {
             const rows = generateRows(10);
             const pw = writer.appendRows(rows, offset);
@@ -1037,6 +1039,7 @@ describe('managedwriter.WriterClient', () => {
           const pendingWrites: PendingWrite[] = [];
           const iterations = new Array(50).fill(1);
           let offset = 0;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           for (const _ of iterations) {
             const rows = generateRows(10);
             const pw = writer.appendRows(rows, offset);
@@ -1056,7 +1059,7 @@ describe('managedwriter.WriterClient', () => {
         }
       }).timeout(2 * 60 * 1000);
 
-      it('every 10 request there is a quota error', async () => {
+      xit('every 10 request there is a RESOURCE_EXAUSTED quota error', async () => {
         bqWriteClient.initialize();
         const client = new WriterClient();
         client.enableWriteRetries(true);
@@ -1115,6 +1118,7 @@ describe('managedwriter.WriterClient', () => {
           const pendingWrites: PendingWrite[] = [];
           const iterations = new Array(50).fill(1);
           let offset = 0;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           for (const _ of iterations) {
             const rows = generateRows(10);
             const pw = writer.appendRows(rows, offset);
@@ -1611,14 +1615,12 @@ describe('managedwriter.WriterClient', () => {
 
     for (const dataset of datasets) {
       try {
-        console.log('getting data for dataset', dataset.id);
         const [metadata] = await dataset.getMetadata();
         const creationTime = Number(metadata.creationTime);
 
-        //if (isResourceStale(creationTime)) {
-        console.log('deleting dataset', dataset.id);
-        await dataset.delete({force: true});
-        //}
+        if (isResourceStale(creationTime)) {
+          await dataset.delete({force: true});
+        }
       } catch (e) {
         console.log(`dataset(${dataset.id}).delete() failed`);
         console.log(e);

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1614,16 +1614,15 @@ describe('managedwriter.WriterClient', () => {
     );
 
     for (const dataset of datasets) {
-      try {
-        const [metadata] = await dataset.getMetadata();
-        const creationTime = Number(metadata.creationTime);
-
-        if (isResourceStale(creationTime)) {
+      const [metadata] = await dataset.getMetadata();
+      const creationTime = Number(metadata.creationTime);
+      if (isResourceStale(creationTime)) {
+        try {
           await dataset.delete({force: true});
+        } catch (e) {
+          console.log(`dataset(${dataset.id}).delete() failed`);
+          console.log(e);
         }
-      } catch (e) {
-        console.log(`dataset(${dataset.id}).delete() failed`);
-        console.log(e);
       }
     }
   }

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it, xit} from 'mocha';
+import {describe, it} from 'mocha';
 import * as uuid from 'uuid';
 import * as gax from 'google-gax';
 import * as sinon from 'sinon';
@@ -1294,7 +1294,7 @@ describe('managedwriter.WriterClient', () => {
         await sleep(100);
         conn.destroy();
         await sleep(100);
-        
+
         // should throw error of reconnection
         assert.notEqual(foundError, null);
         assert.equal(foundError!.message.includes('reconnect'), true);

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -922,10 +922,6 @@ describe('managedwriter.WriterClient', () => {
             destinationTable: parent,
           });
 
-          connection.onConnectionError(err => {
-            console.log('flaky test error:', err);
-          });
-
           const writer = new JSONWriter({
             connection,
             protoDescriptor,
@@ -958,6 +954,7 @@ describe('managedwriter.WriterClient', () => {
         bqWriteClient.initialize();
         const client = new WriterClient();
         client.enableWriteRetries(true);
+        client.setMaxRetryAttempts(100); // aggresive retries
         client.setClient(bqWriteClient);
 
         try {
@@ -974,11 +971,6 @@ describe('managedwriter.WriterClient', () => {
           const connection = await client.createStreamConnection({
             streamType: managedwriter.PendingStream,
             destinationTable: parent,
-          });
-          client['_retrySettings'].maxRetryAttempts = 100; // aggresive retries
-
-          connection.onConnectionError(err => {
-            console.log('flaky conn error:', err);
           });
 
           const writer = new JSONWriter({
@@ -1018,6 +1010,7 @@ describe('managedwriter.WriterClient', () => {
         bqWriteClient.initialize();
         const client = new WriterClient();
         client.enableWriteRetries(true);
+        client.setMaxRetryAttempts(10);
         client.setClient(bqWriteClient);
 
         try {
@@ -1034,11 +1027,6 @@ describe('managedwriter.WriterClient', () => {
           const connection = await client.createStreamConnection({
             streamType: managedwriter.PendingStream,
             destinationTable: parent,
-          });
-          client['_retrySettings'].maxRetryAttempts = 10;
-
-          connection.onConnectionError(err => {
-            console.log('flaky test error:', err);
           });
 
           const writer = new JSONWriter({
@@ -1108,10 +1096,6 @@ describe('managedwriter.WriterClient', () => {
                 return false;
               }
             );
-
-          connection.onConnectionError(err => {
-            console.log('flaky test error:', err);
-          });
 
           const writer = new JSONWriter({
             connection,

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1078,7 +1078,7 @@ describe('managedwriter.WriterClient', () => {
             .stub(conn, 'write')
             .callsFake(
               (
-                chunk: any,
+                chunk: unknown,
                 cb?: ((error: Error | null | undefined) => void) | undefined
               ): boolean => {
                 const req = chunk as AppendRowRequest;


### PR DESCRIPTION
This PR fix an issue that can happen when an error is returned by the service side and we trigger a reconnect, in some cases where a in-flight/pending write is still waiting for response can be left without any ack/nack. 

Towards internal b/329875851
