### PR TITLE
test: remove range parsing as is now supported on latest bigquery lib

### DIFF
--- a/samples/test/writeClient.js
+++ b/samples/test/writeClient.js
@@ -307,20 +307,6 @@ describe('writeClient', () => {
           if (name === 'numeric_col' || name === 'bignumeric_col') {
             value = value.toNumber();
           }
-          if (name === 'range_col') {
-            // Parse range while not supported on @google-cloud/bigquery pkg
-            const [start, end] = value
-              .replace('[', '')
-              .replace(')', '')
-              .split(',');
-
-            const dtStart = new Date(start / 1000);
-            const dtEnd = new Date(end / 1000);
-            value = {
-              start: BigQuery.timestamp(dtStart).value,
-              end: BigQuery.timestamp(dtEnd).value,
-            };
-          }
           return {[name]: value};
         });
     });


### PR DESCRIPTION
With the latest version of [@google-cloud/bigquery v7.7.0](https://github.com/googleapis/nodejs-bigquery/releases/tag/v7.7.0), now the `RANGE` type is parsed and presented to users with a custom type, so no need to manually parse it.
