### PR TITLE
feat: add getWriteStream and createWriteStreamFullResponse methods

### DIFF
--- a/samples/append_rows_buffered.js
+++ b/samples/append_rows_buffered.js
@@ -36,7 +36,7 @@ function main(
     const writeClient = new WriterClient({projectId: projectId});
 
     try {
-      const writeStream = await writeClient.createFullWriteStream({
+      const writeStream = await writeClient.createWriteStreamFullResponse({
         streamType,
         destinationTable,
       });

--- a/samples/append_rows_buffered.js
+++ b/samples/append_rows_buffered.js
@@ -36,17 +36,13 @@ function main(
     const writeClient = new WriterClient({projectId: projectId});
 
     try {
-      const streamId = await writeClient.createWriteStream({
+      const writeStream = await writeClient.createFullWriteStream({
         streamType,
         destinationTable,
       });
+      const streamId = writeStream.name;
       console.log(`Stream created: ${streamId}`);
 
-      // Get table schema from WriteStream metadata.
-      const writeStream = await writeClient.getWriteStream({
-        streamId,
-        view: 'FULL',
-      });
       const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
         writeStream.tableSchema,
         'root'

--- a/samples/append_rows_json_writer_commited.js
+++ b/samples/append_rows_json_writer_commited.js
@@ -36,17 +36,13 @@ function main(
     const writeClient = new WriterClient({projectId});
 
     try {
-      const streamId = await writeClient.createWriteStream({
+      const writeStream = await writeClient.createFullWriteStream({
         streamType,
         destinationTable,
       });
+      const streamId = writeStream.name;
       console.log(`Stream created: ${streamId}`);
 
-      // Get table schema from WriteStream metadata.
-      const writeStream = await writeClient.getWriteStream({
-        streamId,
-        view: 'FULL',
-      });
       const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
         writeStream.tableSchema,
         'root'

--- a/samples/append_rows_json_writer_commited.js
+++ b/samples/append_rows_json_writer_commited.js
@@ -22,7 +22,6 @@ function main(
   // [START bigquerystorage_jsonstreamwriter_commited]
   const {adapt, managedwriter} = require('@google-cloud/bigquery-storage');
   const {WriterClient, JSONWriter} = managedwriter;
-  const {BigQuery} = require('@google-cloud/bigquery');
 
   async function appendJSONRowsCommitedStream() {
     /**
@@ -35,25 +34,23 @@ function main(
     const destinationTable = `projects/${projectId}/datasets/${datasetId}/tables/${tableId}`;
     const streamType = managedwriter.CommittedStream;
     const writeClient = new WriterClient({projectId});
-    const bigquery = new BigQuery({projectId: projectId});
 
     try {
-      const dataset = bigquery.dataset(datasetId);
-      const table = await dataset.table(tableId);
-      const [metadata] = await table.getMetadata();
-      const {schema} = metadata;
-      const storageSchema =
-        adapt.convertBigQuerySchemaToStorageTableSchema(schema);
-      const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
-        storageSchema,
-        'root'
-      );
-
       const streamId = await writeClient.createWriteStream({
         streamType,
         destinationTable,
       });
       console.log(`Stream created: ${streamId}`);
+
+      // Get table schema from WriteStream metadata.
+      const writeStream = await writeClient.getWriteStream({
+        streamId,
+        view: 'FULL',
+      });
+      const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
+        writeStream.tableSchema,
+        'root'
+      );
 
       const connection = await writeClient.createStreamConnection({
         streamId,

--- a/samples/append_rows_json_writer_commited.js
+++ b/samples/append_rows_json_writer_commited.js
@@ -36,7 +36,7 @@ function main(
     const writeClient = new WriterClient({projectId});
 
     try {
-      const writeStream = await writeClient.createFullWriteStream({
+      const writeStream = await writeClient.createWriteStreamFullResponse({
         streamType,
         destinationTable,
       });

--- a/samples/append_rows_pending.js
+++ b/samples/append_rows_pending.js
@@ -55,10 +55,11 @@ function main(
     const streamType = managedwriter.PendingStream;
     const writeClient = new WriterClient({projectId});
     try {
-      const streamId = await writeClient.createWriteStream({
+      const writeStream = await writeClient.createFullWriteStream({
         streamType,
         destinationTable,
       });
+      const streamId = writeStream.name;
       console.log(`Stream created: ${streamId}`);
 
       const connection = await writeClient.createStreamConnection({

--- a/samples/append_rows_pending.js
+++ b/samples/append_rows_pending.js
@@ -55,7 +55,7 @@ function main(
     const streamType = managedwriter.PendingStream;
     const writeClient = new WriterClient({projectId});
     try {
-      const writeStream = await writeClient.createFullWriteStream({
+      const writeStream = await writeClient.createWriteStreamFullResponse({
         streamType,
         destinationTable,
       });

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -36,7 +36,7 @@ function main(
     const writeClient = new WriterClient({projectId: projectId});
 
     try {
-      const writeStream = await writeClient.createFullWriteStream({
+      const writeStream = await writeClient.createWriteStreamFullResponse({
         streamType,
         destinationTable,
       });

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -22,7 +22,6 @@ function main(
   // [START bigquerystorage_jsonstreamwriter_pending]
   const {adapt, managedwriter} = require('@google-cloud/bigquery-storage');
   const {WriterClient, JSONWriter} = managedwriter;
-  const {BigQuery} = require('@google-cloud/bigquery');
 
   async function appendRowsPendingStream() {
     /**
@@ -35,25 +34,23 @@ function main(
     const destinationTable = `projects/${projectId}/datasets/${datasetId}/tables/${tableId}`;
     const streamType = managedwriter.PendingStream;
     const writeClient = new WriterClient({projectId: projectId});
-    const bigquery = new BigQuery({projectId: projectId});
 
     try {
-      const dataset = bigquery.dataset(datasetId);
-      const table = await dataset.table(tableId);
-      const [metadata] = await table.getMetadata();
-      const {schema} = metadata;
-      const storageSchema =
-        adapt.convertBigQuerySchemaToStorageTableSchema(schema);
-      const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
-        storageSchema,
-        'root'
-      );
-
       const streamId = await writeClient.createWriteStream({
         streamType,
         destinationTable,
       });
       console.log(`Stream created: ${streamId}`);
+
+      // Get table schema from WriteStream metadata.
+      const writeStream = await writeClient.getWriteStream({
+        streamId,
+        view: 'FULL',
+      });
+      const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
+        writeStream.tableSchema,
+        'root'
+      );
 
       const connection = await writeClient.createStreamConnection({
         streamId,

--- a/samples/append_rows_table_to_proto2.js
+++ b/samples/append_rows_table_to_proto2.js
@@ -36,17 +36,13 @@ function main(
     const writeClient = new WriterClient({projectId: projectId});
 
     try {
-      const streamId = await writeClient.createWriteStream({
+      const writeStream = await writeClient.createFullWriteStream({
         streamType,
         destinationTable,
       });
+      const streamId = writeStream.name;
       console.log(`Stream created: ${streamId}`);
 
-      // Get table schema from WriteStream metadata.
-      const writeStream = await writeClient.getWriteStream({
-        streamId,
-        view: 'FULL',
-      });
       const protoDescriptor = adapt.convertStorageSchemaToProto2Descriptor(
         writeStream.tableSchema,
         'root'

--- a/src/adapt/proto.ts
+++ b/src/adapt/proto.ts
@@ -14,6 +14,7 @@
 
 import * as protos from '../../protos/protos';
 import {bqTypeToFieldTypeMap, convertModeToLabel} from './proto_mappings';
+import {normalizeFieldType} from './schema_mappings';
 
 type TableSchema = protos.google.cloud.bigquery.storage.v1.ITableSchema;
 type TableFieldSchema =
@@ -92,12 +93,13 @@ function convertStorageSchemaToFileDescriptorInternal(
   for (const field of schema.fields ?? []) {
     fNumber += 1;
     const currentScope = `${scope}_${field.name}`;
+    const normalizedType = normalizeFieldType(field);
     if (
-      field.type === TableFieldSchema.Type.STRUCT ||
-      field.type === TableFieldSchema.Type.RANGE
+      normalizedType === TableFieldSchema.Type.STRUCT ||
+      normalizedType === TableFieldSchema.Type.RANGE
     ) {
       let subSchema: TableSchema = {};
-      switch (field.type) {
+      switch (normalizedType) {
         case TableFieldSchema.Type.STRUCT:
           subSchema = {
             fields: field.fields,
@@ -245,7 +247,7 @@ function convertTableFieldSchemaToFieldDescriptorProto(
   useProto3: boolean
 ): FieldDescriptorProto {
   const name = field.name;
-  const type = field.type;
+  const type = normalizeFieldType(field);
   if (!type) {
     throw Error(`table field ${name} missing type`);
   }

--- a/src/adapt/schema_mappings.ts
+++ b/src/adapt/schema_mappings.ts
@@ -52,6 +52,19 @@ export const fieldTypeMap: Record<string, StorageTableFieldType> = {
     protos.google.cloud.bigquery.storage.v1.TableFieldSchema.Type.GEOGRAPHY,
 };
 
+export function normalizeFieldType(
+  field: StorageTableField
+): StorageTableField['type'] {
+  if (field.type) {
+    const ftype = fieldTypeMap[field.type];
+    if (!ftype) {
+      return field.type;
+    }
+    return ftype;
+  }
+  return field.type;
+}
+
 export const modeMap: Record<string, StorageTableField['mode']> = {
   NULLABLE:
     protos.google.cloud.bigquery.storage.v1.TableFieldSchema.Mode.NULLABLE,

--- a/src/managedwriter/writer_client.ts
+++ b/src/managedwriter/writer_client.ts
@@ -173,7 +173,7 @@ export class WriterClient {
     },
     options?: CallOptions
   ): Promise<string> {
-    const stream = await this.createFullWriteStream(request, options);
+    const stream = await this.createWriteStreamFullResponse(request, options);
     if (stream.name) {
       return stream.name;
     }
@@ -199,7 +199,7 @@ export class WriterClient {
    *   of `projects/{project}/datasets/{dataset}/tables/{table}`.
    * @returns {Promise<WriteStream>}} - The promise which resolves to the WriteStream.
    */
-  async createFullWriteStream(
+  async createWriteStreamFullResponse(
     request: {
       streamType: WriteStreamType;
       destinationTable: string;

--- a/src/managedwriter/writer_client.ts
+++ b/src/managedwriter/writer_client.ts
@@ -17,7 +17,12 @@ import type {CallOptions, ClientOptions} from 'google-gax';
 import * as protos from '../../protos/protos';
 
 import {BigQueryWriteClient} from '../v1';
-import {WriteStreamType, DefaultStream, streamTypeToEnum} from './stream_types';
+import {
+  WriteStreamType,
+  DefaultStream,
+  streamTypeToEnum,
+  WriteStream,
+} from './stream_types';
 import {StreamConnection} from './stream_connection';
 
 type StreamConnections = {
@@ -29,6 +34,9 @@ type RetrySettings = {
 };
 type CreateWriteStreamRequest =
   protos.google.cloud.bigquery.storage.v1.ICreateWriteStreamRequest;
+type GetWriteStreamRequest =
+  protos.google.cloud.bigquery.storage.v1.IGetWriteStreamRequest;
+type WriteStreamView = protos.google.cloud.bigquery.storage.v1.WriteStreamView;
 type BatchCommitWriteStreamsRequest =
   protos.google.cloud.bigquery.storage.v1.IBatchCommitWriteStreamsRequest;
 type BatchCommitWriteStreamsResponse =
@@ -181,6 +189,41 @@ export class WriterClient {
     } catch {
       throw new Error('Stream connection failed');
     }
+  }
+
+  /**
+   * Gets information about a write stream.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.streamId
+   *   Required. Name of the stream to get, in the form of
+   *   `projects/{project}/datasets/{dataset}/tables/{table}/streams/{stream}`
+   * @param {WriteStreamView} request.view
+   *   Indicates whether to get full or partial view of the WriteStream. If
+   *   not set, view returned will be basic.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise<WriteStream>}} - The promise which resolves to the WriteStream.
+   */
+  async getWriteStream(
+    request: {
+      streamId: string;
+      view?: WriteStreamView;
+    },
+    options?: CallOptions
+  ): Promise<WriteStream> {
+    await this.initialize();
+    const {streamId, view} = request;
+    const getReq: GetWriteStreamRequest = {
+      name: streamId,
+      view,
+    };
+    const [response] = await this._client.getWriteStream(getReq, options);
+    if (typeof [response] === undefined) {
+      throw new gax.GoogleError(`${response}`);
+    }
+    return response;
   }
 
   /**

--- a/src/managedwriter/writer_client.ts
+++ b/src/managedwriter/writer_client.ts
@@ -320,7 +320,7 @@ export class WriterClient {
     }
     if (destinationTable) {
       if (streamType) {
-        const streamId = await this.createWriteStream({
+        streamId = await this.createWriteStream({
           streamType,
           destinationTable,
         });

--- a/test/adapt/schema.ts
+++ b/test/adapt/schema.ts
@@ -187,7 +187,6 @@ describe('Adapt Schemas', () => {
       if (!storageSchema) {
         throw Error('null storage schema');
       }
-      console.log('storageSchema', storageSchema);
       assert.deepEqual(storageSchema, {
         fields: [
           {


### PR DESCRIPTION
Add wrapper for `getWriteStream` method. We can changes samples to use this method to get the table schema, instead of using the other BigQuery Node library. 