### PR TITLE
ci: fix npm pack/publish by removing import package.json

### DIFF
--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import * as assert from 'assert';
+import {readFileSync} from 'fs';
+import * as path from 'path';
 import {describe, it} from 'mocha';
 import * as uuid from 'uuid';
 import * as gax from 'google-gax';
@@ -25,7 +27,10 @@ import {ClientOptions} from 'google-gax';
 import * as customerRecordProtoJson from '../samples/customer_record.json';
 import {JSONEncoder} from '../src/managedwriter/encoder';
 import {PendingWrite} from '../src/managedwriter/pending_write';
-import * as pkg from '../package.json';
+
+const pkg = JSON.parse(
+  readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
+);
 
 const sandbox = sinon.createSandbox();
 afterEach(() => sandbox.restore());


### PR DESCRIPTION
v4.7.0 was published with no source files. We managed to reproduce the issue by using `nvm` and setting to node to v14 and npm v6, which seems to have issues when a `package.json` exists on the build folder.  The file causing this is a `system-test`, so this PR changes it to read at runtime the `package.json` file, this way it is not contained on the build folder.

Fixes #457 🦕
