### PR TITLE
Emit stream events in stream_connection.ts

### DIFF
--- a/src/managedwriter/stream_connection.ts
+++ b/src/managedwriter/stream_connection.ts
@@ -107,12 +107,15 @@ export class StreamConnection extends EventEmitter {
     });
     this._connection.on('pause', () => {
       this.trace('connection paused');
+      this.emit('pause');
     });
     this._connection.on('resume', () => {
       this.trace('connection resumed');
+      this.emit('resume');
     });
     this._connection.on('end', () => {
       this.trace('connection ended');
+      this.emit('end');
     });
   }
 
@@ -364,6 +367,7 @@ export class StreamConnection extends EventEmitter {
     );
     this.close();
     this.open();
+    this.emit('reconnect');
   }
 
   /**
@@ -375,6 +379,7 @@ export class StreamConnection extends EventEmitter {
     }
     this._connection.end();
     this._connection.removeAllListeners();
+    this.emit('close');
     this._connection.destroy();
     this._connection = null;
   }


### PR DESCRIPTION
When using the managedwriter, I found that the connection often needs to reconnect, but my calling code was unable to determine when this happens.

In this commit I have forwarded the various events from the underlying connection, except 'close' is only called when the stream_connection has been instructed to close, and a new event 'reconnect' is emitted when the stream has been closed and reopened.

Fixes #529 🦕
