### PR TITLE
fix: required table fields with value expression should be proto optional

### DIFF
--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/adapt/proto.ts
+++ b/src/adapt/proto.ts
@@ -319,7 +319,11 @@ function convertTableFieldSchemaToFieldDescriptorProto(
   if (!type) {
     throw Error(`table field ${name} missing type`);
   }
-  const label = convertModeToLabel(field.mode, useProto3);
+  const label = convertModeToLabel(
+    field.mode,
+    field.defaultValueExpression,
+    useProto3
+  );
   let fdp: FieldDescriptorProto;
   if (
     type === TableFieldSchema.Type.STRUCT ||

--- a/src/adapt/proto.ts
+++ b/src/adapt/proto.ts
@@ -61,6 +61,10 @@ const packedTypes: FieldDescriptorProtoType[] = [
  * column name doesn't have any valid characters, we generate a placeholder name using
  * the field number `field{fieldNumber}`.
  *
+ * If a column is required, but has a `defaultValueExpression` set, the resulting
+ * protobuf field will be optional, so the backend service can fill data with the
+ * given expression when no value is set.
+ *
  * @param schema - a BigQuery Storage TableSchema.
  * @param scope - scope to namespace protobuf structs.
  * @returns DescriptorProto
@@ -86,6 +90,10 @@ export function convertStorageSchemaToProto2Descriptor(
  * characters from the column name and replacing all dashes with underscores. If the
  * column name doesn't have any valid characters, we generate a placeholder name using
  * the field number `field{fieldNumber}`.
+ *
+ * If a column is required, but has a `defaultValueExpression` set, the resulting
+ * protobuf field will be optional, so the backend service can fill data with the
+ * given expression when no value is set.
  *
  * @param schema - a Bigquery TableSchema.
  * @param scope - scope to namespace protobuf structs.

--- a/src/adapt/proto_mappings.ts
+++ b/src/adapt/proto_mappings.ts
@@ -104,12 +104,23 @@ export const bqModeToFieldLabelMapProto3: Record<
 
 export function convertModeToLabel(
   mode: TableFieldSchema['mode'],
+  defaultValueExpression: TableFieldSchema['defaultValueExpression'],
   useProto3: Boolean
 ): FieldDescriptorProtoLabel | null {
   if (!mode) {
     return null;
   }
-  return useProto3
+  const label = useProto3
     ? bqModeToFieldLabelMapProto3[mode]
     : bqModeToFieldLabelMapProto2[mode];
+  if (
+    label === FieldDescriptorProto.Label.LABEL_REQUIRED &&
+    defaultValueExpression &&
+    !useProto3
+  ) {
+    // override LABEL_REQUIRED when there is a default value expression
+    // so the backend can fill the data for the user
+    return FieldDescriptorProto.Label.LABEL_OPTIONAL;
+  }
+  return label;
 }

--- a/src/adapt/schema.ts
+++ b/src/adapt/schema.ts
@@ -39,6 +39,10 @@ type ITableFieldSchema = {
    */
   name?: string;
   /**
+   * Optional. A SQL expression to specify the [default value] (https://cloud.google.com/bigquery/docs/default-values) for this field.
+   */
+  defaultValueExpression?: string;
+  /**
    * [Required] The field data type. Possible values include STRING, BYTES, INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as FLOAT), NUMERIC, BIGNUMERIC, BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME, DATETIME, INTERVAL, RECORD (where RECORD indicates that the field contains a nested schema) or STRUCT (same as RECORD).
    */
   type?: string;
@@ -88,6 +92,10 @@ function bqFieldToStorageField(field: ITableFieldSchema): StorageTableField {
   const out: StorageTableField = {
     name: field.name,
   };
+
+  if (field.defaultValueExpression) {
+    out.defaultValueExpression = field.defaultValueExpression;
+  }
 
   if (field.description) {
     out.description = field.description;

--- a/system-test/managed_writer_client_test.ts
+++ b/system-test/managed_writer_client_test.ts
@@ -1025,6 +1025,7 @@ describe('managedwriter.WriterClient', () => {
         {
           name: 'id',
           type: 'STRING',
+          mode: 'REQUIRED',
           defaultValueExpression: 'GENERATE_UUID()',
         },
         {
@@ -1081,6 +1082,7 @@ describe('managedwriter.WriterClient', () => {
       // change MVI config
       writer.setDefaultMissingValueInterpretation('NULL_VALUE');
       writer.setMissingValueInterpretations({
+        id: 'DEFAULT_VALUE',
         updated_at: 'DEFAULT_VALUE',
       });
 
@@ -1115,23 +1117,23 @@ describe('managedwriter.WriterClient', () => {
       assert.strictEqual(rows.length, 4);
 
       const first = rows[0];
-      assert.notEqual(first.id, null);
+      assert.notEqual(first.id, '');
       assert.notEqual(first.created_at, null);
       assert.equal(first.updated_at, null);
 
       const second = rows[1];
-      assert.notEqual(second.id, null);
+      assert.notEqual(second.id, '');
       assert.notEqual(second.created_at, null);
       assert.equal(second.updated_at, null);
 
       // After change on MVI config
       const third = rows[2];
-      assert.equal(third.id, null);
+      assert.notEqual(third.id, '');
       assert.equal(third.created_at, null);
       assert.notEqual(third.updated_at, null);
 
       const forth = rows[3];
-      assert.equal(forth.id, null);
+      assert.notEqual(forth.id, '');
       assert.equal(forth.created_at, null);
       assert.notEqual(forth.updated_at, null);
 

--- a/test/adapt/proto.ts
+++ b/test/adapt/proto.ts
@@ -51,6 +51,12 @@ describe('Adapt Protos', () => {
             type: 'BOOL',
             mode: 'REPEATED',
           },
+          {
+            name: 'id',
+            type: 'STRING',
+            mode: 'REQUIRED',
+            defaultValueExpression: 'GENERATE_UUID()',
+          },
         ],
       };
       const storageSchema =


### PR DESCRIPTION
When a BigQuery table column mode is set to `REQUIRED`, when converted to a protobuf label, it was being converted as `LABEL_REQUIRED`. This would make protobufjs encoding methods to set an empty value to it when converting to the wire format. But if the column has a `defaultValueExpression` and we want the backend to fill the data, we need to let the value stay `null | undefined`. 

This PR checks if there is a `defaultValueExpression` defined on the column and change the label to `LABEL_OPTIONAL` to let the backend fill the data.

Fixes #531 🦕
