### PR TITLE
fix: limit protobufjs version to avoid breaking version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "google-gax": "^5.0.1-rc.0"
   },
   "peerDependencies": {
-    "protobufjs": "^7.2.4"
+    "protobufjs": "^7.2.4 - 7.5.0"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^8.0.0",


### PR DESCRIPTION
Protobufjs released a version that breaks behavior for ProtoDescriptors. See more on https://github.com/protobufjs/protobuf.js/issues/2072

Fixes #559 #558 #557 #556 #555 #554 #565
