### PR TITLE
fix: update gax version, adjust monkeypatch for protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "apache-arrow": "^19.0.1",
     "core-js": "^3.41.0",
     "extend": "^3.0.2",
-    "google-auth-library": "^10.0.0-rc.1",
-    "google-gax": "^5.0.1-rc.0"
+    "google-auth-library": "^10.0.0",
+    "google-gax": "^5.0.0"
+
   },
   "peerDependencies": {
     "protobufjs": "^7.2.4 - 7.5.0"

--- a/src/protobuf/index.ts
+++ b/src/protobuf/index.ts
@@ -22,10 +22,12 @@ declare module 'protobufjs' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Type {
     let fromDescriptor: (
-      descriptor: Message<IDescriptorProto> | IDescriptorProto
+      descriptor: Message<IDescriptorProto> | IDescriptorProto,
     ) => Type;
   }
   interface Type {
-    toDescriptor(protoVersion: string): Message<IDescriptorProto> & IDescriptorProto;
+    toDescriptor(
+      protoVersion: string,
+    ): Message<IDescriptorProto> & IDescriptorProto;
   }
 }

--- a/src/protobuf/index.ts
+++ b/src/protobuf/index.ts
@@ -21,7 +21,11 @@ type IDescriptorProto = protos.google.protobuf.IDescriptorProto;
 declare module 'protobufjs' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Type {
-    let toDescriptor: (protoVersion: string) => IDescriptorProto;
-    let fromDescriptor: (descriptor: IDescriptorProto) => Type;
+    let fromDescriptor: (
+      descriptor: Message<IDescriptorProto> | IDescriptorProto
+    ) => Type;
+  }
+  interface Type {
+    toDescriptor(protoVersion: string): Message<IDescriptorProto> & IDescriptorProto;
   }
 }


### PR DESCRIPTION
This is similar to #407 - I updated the monkeypatch of the protobufjs descriptor to be more like what we see in [`proto-loader`](https://github.com/murgatroid99/grpc-node/blob/31c8b710b3ff2f4d7b0613d1af62d597bc0a4ff2/packages/proto-loader/src/index.ts#L64-L68) and it seemed to fix our compile errors