### PR TITLE
chore: replace old teams with cloud-sdk-nodejs-team and bigquery-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# Unless specified, the cloud-sdk-nodejs-team is the default owner for nodejs repositories.
-* @googleapis/bigquery-team @googleapis/cloud-sdk-nodejs-team
+# Unless specified, the jsteam is the default owner for nodejs repositories.
+*     @googleapis/bigquery-team @googleapis/cloud-sdk-nodejs-team @googleapis/jsteam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/api-bigquery @googleapis/jsteam
+# Unless specified, the cloud-sdk-nodejs-team is the default owner for nodejs repositories.
+* @googleapis/bigquery-team @googleapis/cloud-sdk-nodejs-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,7 +11,7 @@
   "name": "bigquerystorage",
   "name_pretty": "Google BigQuery Storage",
   "api_id": "bigquerystorage.googleapis.com",
-  "codeowner_team": "@googleapis/api-bigquery",
+  "codeowner_team": "@googleapis/bigquery-team @googleapis/cloud-sdk-nodejs-team",
   "api_shortname": "bigquerystorage",
   "library_type": "GAPIC_AUTO"
 }


### PR DESCRIPTION
This PR replaces the old api-bigquery with bigquery-team and jsteam with cloud-sdk-nodejs-team.

b/478003109