### PR TITLE
docs: remove inline comment about arrowSerializationOptions

### DIFF
--- a/src/reader/read_client.ts
+++ b/src/reader/read_client.ts
@@ -150,9 +150,6 @@ export class ReadClient {
       maxStreamCount: maxStreamCount,
     };
     if (request.arrowSerializationOptions) {
-      // Use Object.assign instead of defining property inline.
-      // We prefer no arrowSerializationOptions property in the JSON request
-      // instead of having an `arrowSerializationOptions: undefined` mapping.
       Object.assign(createReq.readSession.readOptions, {
         arrowSerializationOptions: request.arrowSerializationOptions,
       });


### PR DESCRIPTION
## Description

As requested in https://github.com/googleapis/nodejs-bigquery-storage/pull/656#discussion_r2879033578, this PR just removes a comment that isn't really necessary.
